### PR TITLE
fix missing unit conversion for scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package implements the most common composite scores used for evaluating dis
 - Revised ACR / EULAR Boolean remission
 - Three-item ACR / EULAR Boolean remission
 
-In addition to composite measures, this package also testing for further remission definitions:
+In addition to composite measures, this package allows testing for further remission definitions:
 
 - SJC28 remission
 - PGA remission

--- a/src/RheumaComposites.jl
+++ b/src/RheumaComposites.jl
@@ -24,6 +24,7 @@ export score
 export isremission
 
 include("utils/units.jl")
+include("utils/valid.jl")
 include("types/components.jl")
 include("types/composites.jl")
 include("types/das28.jl")

--- a/src/types/boolean.jl
+++ b/src/types/boolean.jl
@@ -4,12 +4,10 @@ struct BooleanRemission <: BooleanComposite
     pga::Unitful.AbstractQuantity
     crp::Unitful.AbstractQuantity
     function BooleanRemission(; t28, s28, pga::Unitful.AbstractQuantity, crp::Unitful.AbstractQuantity)
-        foreach([t28, s28]) do joints
-            Base.isbetween(0, joints, 28) || throw(DomainError(joints, "only defined for 0 < joints < 28."))
-        end
-        Base.isbetween(0units.brem_vas, units.brem_vas(pga), 100units.brem_vas) || throw(DomainError(units.brem_vas(pga), "only defined for 0 mm < pga < 100 mm."))
-        units.brem_crp(crp) >= 0units.brem_crp || throw(DomainError(units.brem_crp(crp), "CRP must be positive."))
-        return new(t28, s28, pga, units.brem_crp(crp))
+        valid_joints.([t28, s28])
+        valid_vas(pga)
+        valid_apr(crp)
+        return new(t28, s28, pga, uconvert(units.brem_crp, crp))
     end
 end
 

--- a/src/types/components.jl
+++ b/src/types/components.jl
@@ -5,9 +5,9 @@
 abstract type AbstractComponent end
 
 struct PGA <: AbstractComponent
-    value::Float64
+    value::Unitful.AbstractQuantity
     function PGA(x)
-        Base.isbetween(0, x, 100) || throw(DomainError(x, "VAS global must be between 0 and 100."))
+        valid_vas(x)
         return new(x)
     end
 end
@@ -15,7 +15,7 @@ end
 struct SJC28 <: AbstractComponent
     value::Int64
     function SJC28(x)
-        Base.isbetween(0, x, 28) || throw(DomainError(x, "only defined for 0 < joints < 28."))
+        valid_joints(x)
         return new(x)
     end
 end

--- a/src/types/das28.jl
+++ b/src/types/das28.jl
@@ -32,13 +32,23 @@ struct DAS28CRP <: DAS28
     s28::Int64
     pga::Unitful.AbstractQuantity
     apr::Unitful.AbstractQuantity
-    function DAS28CRP(; t28, s28, pga::Unitful.AbstractQuantity, apr::Unitful.AbstractQuantity)
-        foreach([t28, s28]) do joints
-            Base.isbetween(0, joints, 28) || throw(DomainError(joints, "only defined for 0 < joints < 28."))
-        end
-        Base.isbetween(0units.das28_vas, units.das28_vas(pga), 100units.das28_vas) || throw(DomainError(units.das28_vas(pga), "only defined for 0cm < pga < 100cm."))
-        apr >= 0units.das28_crp || throw(DomainError(apr, "CRP must be positive."))
-        return new(t28, s28, units.das28_vas(pga), units.das28_crp(apr))
+    function DAS28CRP(;
+        t28,
+        s28,
+        pga::Unitful.AbstractQuantity,
+        apr::Unitful.AbstractQuantity,
+    )
+        valid_joints.([t28, s28])
+        valid_vas(pga)
+        valid_apr(apr)
+        
+        # Must convert because weights do not adjust to measurement
+        return new(
+            t28,
+            s28,
+            uconvert(units.das28_vas, pga),
+            uconvert(units.das28_crp, apr)
+        )
     end
 end
 
@@ -72,13 +82,21 @@ struct DAS28ESR <: DAS28
     s28::Int64
     pga::Unitful.AbstractQuantity
     apr::Unitful.AbstractQuantity
-    function DAS28ESR(; t28, s28, pga::Unitful.AbstractQuantity, apr::Unitful.AbstractQuantity)
-        foreach([t28, s28]) do joints
-            Base.isbetween(0, joints, 28) || throw(DomainError(joints, "only defined for 0 < joints < 28."))
-        end
-        Base.isbetween(0units.das28_vas, units.das28_vas(pga), 100units.das28_vas) || throw(DomainError(units.das28_vas(pga), "only defined for 0 mm < pga < 100 mm."))
-        units.das28_esr(apr) >= 0units.das28_esr || throw(DomainError(units.das28_esr(apr), "ESR must be positive."))
-        return new(t28, s28, units.das28_vas(pga), units.das28_esr(apr))
+    function DAS28ESR(;
+        t28,
+        s28,
+        pga::Unitful.AbstractQuantity,
+        apr::Unitful.AbstractQuantity,
+    )
+        valid_joints.([t28, s28])
+        valid_vas(pga)
+        valid_apr(apr)
+        return new(
+            t28,
+            s28,
+            uconvert(units.das28_vas, pga),
+            uconvert(units.das28_esr, apr)
+        )
     end
 end
 

--- a/src/types/sdai.jl
+++ b/src/types/sdai.jl
@@ -28,14 +28,25 @@ struct SDAI <: ContinuousComposite
     pga::Unitful.AbstractQuantity
     ega::Unitful.AbstractQuantity
     crp::Unitful.AbstractQuantity
-    function SDAI(; t28, s28, pga::Unitful.AbstractQuantity, ega::Unitful.AbstractQuantity, crp::Unitful.AbstractQuantity)
-        foreach([t28, s28]) do joints
-            Base.isbetween(0, joints, 28) || throw(DomainError(joints, "only defined for 0 < joints < 28."))
-        end
-        Base.isbetween(0units.sdai_vas, units.sdai_vas(pga), 10units.sdai_vas) || throw(DomainError(units.sdai_vas(pga), "only defined for 0 cm < pga < 10 cm."))
-        Base.isbetween(0units.sdai_vas, units.sdai_vas(ega), 10units.sdai_vas) || throw(DomainError(units.sdai_vas(pga), "only defined for 0 cm < ega < 10 cm."))
-        units.sdai_crp(crp) >= 0units.sdai_crp || throw(DomainError(units.sdai_crp(crp), "ESR must be positive."))
-        return new(t28, s28, units.sdai_vas(pga), units.sdai_vas(ega), units.sdai_crp(crp))
+    function SDAI(;
+        t28,
+        s28,
+        pga::Unitful.AbstractQuantity,
+        ega::Unitful.AbstractQuantity,
+        crp::Unitful.AbstractQuantity,
+    )
+        valid_joints.([t28, s28])
+        valid_vas.([pga, ega])
+        valid_apr(crp)
+        
+        # Must convert because weights do not adjust to measurement
+        return new(
+            t28,
+            s28,
+            uconvert(units.sdai_vas, pga),
+            uconvert(units.sdai_vas, ega),
+            uconvert(units.sdai_crp, crp)
+        )
     end
 end
 

--- a/src/utils/remission.jl
+++ b/src/utils/remission.jl
@@ -2,7 +2,7 @@ isremission(x::DAS28ESR) = score(x) < 2.6
 isremission(x::DAS28CRP) = score(x) < 2.4
 isremission(x::SDAI) = score(x) <= 3.3
 
-isremission(x::PGA) = x.value <= 10.0
+isremission(x::PGA) = x.value <= 10.0u"mm"
 isremission(x::SJC28) = x.value == 0
 
 function isremission(x::BooleanRemission)

--- a/src/utils/valid.jl
+++ b/src/utils/valid.jl
@@ -1,0 +1,11 @@
+function valid_joints(x)
+    Base.isbetween(0, x, 28) ||
+        throw(DomainError(x, "must be 0 < joints < 28."))
+end
+
+function valid_vas(x)
+    Base.isbetween(0u"cm", uconvert(u"cm", x), 10u"cm") ||
+        throw(DomainError(x, "must be 0 cm < VAS < 10 cm."))
+end
+
+valid_apr(x) = 0 <= ustrip(x)

--- a/test/types/components.jl
+++ b/test/types/components.jl
@@ -1,10 +1,10 @@
 @testset "PGA" begin
-    @test PGA(90) isa AbstractComponent
-    @test PGA(90).value isa Float64
-    @test try PGA(101) catch e; e isa DomainError end
-    @test try PGA(-2) catch e; e isa DomainError end
-    @test !isremission(PGA(90))
-    @test isremission(PGA(4))
+    @test PGA(90u"mm") isa AbstractComponent
+    @test PGA(90u"mm").value isa Unitful.AbstractQuantity
+    @test try PGA(101u"mm") catch e; e isa DomainError end
+    @test try PGA(-2u"mm") catch e; e isa DomainError end
+    @test !isremission(PGA(90u"mm"))
+    @test isremission(PGA(4u"mm"))
 end
 
 @testset "SJC28" begin

--- a/test/types/das28.jl
+++ b/test/types/das28.jl
@@ -1,6 +1,11 @@
-# Dummy DAS28ESR for testing
+# Dummy DAS28s for testing
 d28e = DAS28ESR(t28=4, s28=5, pga=12u"mm", apr=44u"mm/hr")
 d28c = DAS28CRP(t28=4, s28=5, pga=12u"mm", apr=44u"mg/L")
+# Test if different unit scales lead to same results
+das28e_u1 = DAS28CRP(t28=0, s28=1, pga=10u"mm", apr=1u"mg/dL")
+das28e_u2 = DAS28CRP(t28=0, s28=1, pga=1u"cm", apr=10u"mg/L")
+das28c_u1 = DAS28CRP(t28=0, s28=1, pga=10u"mm", apr=1u"mg/dL")
+das28c_u2 = DAS28CRP(t28=0, s28=1, pga=1u"cm", apr=10u"mg/L")
 
 # A reference value for comparison
 # calculated using https://www.4s-dawn.com/DAS28/
@@ -23,11 +28,13 @@ end
     @test score(d28e) isa Float64
     @test score(d28e) ≈ intercept(d28e) + sum(weight(d28e)) atol = 1e-3
     @test score(d28e) ≈ ref_value_esr atol = 1e-2
+    @test score(das28e_u1) ≈ score(das28e_u2) atol = 1e-3
 end
 
 @testset "DAS28ESR Remission" begin
     @test !isremission(d28e)
     @test isremission(DAS28ESR(t28=0, s28=0, pga=8u"mm", apr=2u"mm/hr"))
+    @test isremission(das28e_u1) == isremission(das28e_u2)
 end
 
 @testset "Construct DAS28CRP" begin
@@ -46,9 +53,11 @@ end
     @test score(d28c) isa Float64
     @test score(d28c) ≈ intercept(d28c) + sum(weight(d28c)) atol = 1e-3
     @test score(d28c) ≈ ref_value_crp atol = 1e-2
+    @test score(das28c_u1) ≈ score(das28c_u2) atol = 1e-3
 end
 
 @testset "DAS28CRP remission" begin
     @test !isremission(d28c)
     @test isremission(DAS28CRP(t28=0, s28=0, pga=8u"mm", apr=2u"mg/L"))
+    @test isremission(das28c_u1) == isremission(das28c_u2)
 end

--- a/test/types/sdai.jl
+++ b/test/types/sdai.jl
@@ -1,5 +1,6 @@
 # Dummy SDAIs for testing
 sdai = SDAI(t28=1, s28=0, pga=1u"cm", ega=0u"cm", crp=0.1u"mg/dL")
+# Test if different unit scales lead to same results
 sdai_u1 = SDAI(t28=0, s28=1, pga=10u"mm", ega=10u"mm", crp=1u"mg/dL")
 sdai_u2 = SDAI(t28=0, s28=1, pga=1u"cm", ega=1u"cm", crp=10u"mg/L")
 
@@ -18,7 +19,7 @@ end
     @test intercept(sdai) == 0.0
     @test score(sdai) isa Float64
     @test score(sdai) ≈ intercept(sdai) + sum(weight(sdai)) atol = 1e-3
-    @test score(sdai) ≈ 3.0 atol = 1e-3
+    @test score(sdai) ≈ 3.0 atol = 1e-2
     @test score(sdai_u1) ≈ score(sdai_u2) atol = 1e-3
 end
 

--- a/test/types/sdai.jl
+++ b/test/types/sdai.jl
@@ -1,5 +1,7 @@
-# Dummy SDAI for testing
+# Dummy SDAIs for testing
 sdai = SDAI(t28=1, s28=0, pga=1u"cm", ega=0u"cm", crp=0.1u"mg/dL")
+sdai_u1 = SDAI(t28=0, s28=1, pga=10u"mm", ega=10u"mm", crp=1u"mg/dL")
+sdai_u2 = SDAI(t28=0, s28=1, pga=1u"cm", ega=1u"cm", crp=10u"mg/L")
 
 @testset "Construct SDAI" begin
     @test sdai isa AbstractComposite
@@ -16,7 +18,8 @@ end
     @test intercept(sdai) == 0.0
     @test score(sdai) isa Float64
     @test score(sdai) ≈ intercept(sdai) + sum(weight(sdai)) atol = 1e-3
-    @test score(sdai) ≈ 3.0 atol = 1e-2
+    @test score(sdai) ≈ 3.0 atol = 1e-3
+    @test score(sdai_u1) ≈ score(sdai_u2) atol = 1e-3
 end
 
 @testset "SDAI Remission" begin


### PR DESCRIPTION
Scoring DAS28 and SDAI requires converting units to those expected by the respective weights. Otherwise, `ustrip` leads to inconsistent results across inputs on different scales (mm, cm).