### PR TITLE
rely on tuple indexing to simplify `categorise`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 /**/.DS_Store
 node_modules
+*_files/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RheumaComposites.jl
+# RheumaComposites.jl <img src='docs/src/assets/logo.svg' align='right' height='135'/>
 
 [![Build Status](https://github.com/simonsteiger/RheumaComposites.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/simonsteiger/RheumaComposites.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://simonsteiger.github.io/RheumaComposites.jl/dev/)

--- a/docs/src/examples/categorisation.md
+++ b/docs/src/examples/categorisation.md
@@ -37,12 +37,12 @@ The cutoffs used per composite and category are:
 | Moderate         | ``\leq`` 5.1    | ``\leq`` 4.6    | ``\leq`` 26.0 | ``\leq`` 22.0 |
 | High             | ``>`` 5.1    | ``>`` 4.6    | ``>`` 26.0 | ``>`` 22.0 |
 
-Internally, these are saved in a `NamedTuple` which you can import with `import RheumaComposites: cont_cutoff`.
+Internally, these are saved in a `NamedTuple` which you can import with `import RheumaComposites: cutoff`.
 To retrieve the cutoff for a Moderate CDAI, you would:
 
 ````@example categorisation
-import RheumaComposites: cont_cutoff
-cont_cutoff.CDAI.moderate
+import RheumaComposites: cutoff
+cutoff.CDAI.moderate
 ````
 
 Note that this only returns the boundary value of the respective category, and that the inclusion of this value varies across **both** composites and categories.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 EditURL = "https://github.com/simonsteiger/RheumaComposites.jl/blob/main/README.md"
 ```
 
-# RheumaComposites.jl
+# RheumaComposites.jl <img src='docs/src/assets/logo.svg' align='right' height='135'/>
 
 [![Build Status](https://github.com/simonsteiger/RheumaComposites.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/simonsteiger/RheumaComposites.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://simonsteiger.github.io/RheumaComposites.jl/dev/)

--- a/examples/categorisation.jl
+++ b/examples/categorisation.jl
@@ -27,12 +27,12 @@ The cutoffs used per composite and category are:
 | Moderate         | ``\leq`` 5.1    | ``\leq`` 4.6    | ``\leq`` 26.0 | ``\leq`` 22.0 | 
 | High             | ``>`` 5.1    | ``>`` 4.6    | ``>`` 26.0 | ``>`` 22.0 | 
 
-Internally, these are saved in a `NamedTuple` which you can import with `import RheumaComposites: cont_cutoff`.
+Internally, these are saved in a `NamedTuple` which you can import with `import RheumaComposites: cutoff`.
 To retrieve the cutoff for a Moderate CDAI, you would:
 =#
 
-import RheumaComposites: cont_cutoff
-cont_cutoff.CDAI.moderate
+import RheumaComposites: cutoff
+cutoff.CDAI.moderate
 
 #=
 Note that this only returns the boundary value of the respective category, and that the inclusion of this value varies across **both** composites and categories.

--- a/src/functions/weight.jl
+++ b/src/functions/weight.jl
@@ -15,15 +15,12 @@ weight(x::Subset{N,T}) where {N,T} = weight(WeightingScheme(T), x)
 
 weight(::IsUnweightable, x::T) where {T} = throw(ErrorException("$(typeof(x)) type is unweightable."))
 
-weight(::IsUnweighted, x::T) where {T} = ustrip.(getproperty.(Ref(x), fieldnames(T)))
+weight(::IsUnweighted, x::T) where {T} = ustrip.(getproperty.(Ref(x), components(x)))
 
 function map_weights(weights, x)
-    weighted_values = map(components(x)) do component
-        component_value = ustrip(getproperty(root(x), component))
-        component_weight = getproperty(weights, component)
-        component_weight(component_value)
-    end
-    return weighted_values
+    component_values = ustrip.(getproperty.(Ref(x), components(x)))
+    component_weights = getproperty.(Ref(weights), components(x))
+    return map((w, v) -> w(v), component_weights, component_values)
 end
 
 function weight(::IsWeighted, x::DAS28)

--- a/src/types/boolean.jl
+++ b/src/types/boolean.jl
@@ -25,7 +25,7 @@ struct BooleanRemission <: BooleanComposite
         valid_joints.([tjc, sjc])
         valid_vas(pga)
         valid_apr(crp)
-        return new(tjc, sjc, pga, uconvert(units.brem_crp, crp))
+        return new(tjc, sjc, uconvert(units.brem_vas, pga), uconvert(units.brem_crp, crp))
     end
 end
 

--- a/src/types/cdai.jl
+++ b/src/types/cdai.jl
@@ -16,10 +16,10 @@ Store component measures of the Clinical Disease Activity Index, or CDAI.
 
 # Categories
 
-- ``<`` $(cont_cutoff.CDAI.low) = Remission
-- ``\\leq`` $(cont_cutoff.CDAI.low) = Low
-- ``\\leq`` $(cont_cutoff.CDAI.moderate) = Moderate
-- ``>`` $(cont_cutoff.CDAI.moderate) = High
+- ``<`` $(cutoff.CDAI.low) = Remission
+- ``\\leq`` $(cutoff.CDAI.low) = Low
+- ``\\leq`` $(cutoff.CDAI.moderate) = Moderate
+- ``>`` $(cutoff.CDAI.moderate) = High
 
 # External links
 

--- a/src/types/das28.jl
+++ b/src/types/das28.jl
@@ -29,10 +29,10 @@ Store the component measures of the DAS28CRP.
 
 # Categories
 
-- ``<`` $(cont_cutoff.DAS28CRP.low) = Remission
-- ``\\leq`` $(cont_cutoff.DAS28CRP.low) = Low
-- ``\\leq`` $(cont_cutoff.DAS28CRP.moderate) = Moderate
-- ``>`` $(cont_cutoff.DAS28CRP.moderate) = High
+- ``<`` $(cutoff.DAS28CRP.low) = Remission
+- ``\\leq`` $(cutoff.DAS28CRP.low) = Low
+- ``\\leq`` $(cutoff.DAS28CRP.moderate) = Moderate
+- ``>`` $(cutoff.DAS28CRP.moderate) = High
 
 # External links
 
@@ -83,10 +83,10 @@ Store the component measures of the DAS28ESR.
 
 # Categories
 
-- ``<`` $(cont_cutoff.DAS28ESR.low) = Remission
-- ``\\leq`` $(cont_cutoff.DAS28ESR.low) = Low
-- ``\\leq`` $(cont_cutoff.DAS28ESR.moderate) = Moderate
-- ``>`` $(cont_cutoff.DAS28ESR.moderate) = High
+- ``<`` $(cutoff.DAS28ESR.low) = Remission
+- ``\\leq`` $(cutoff.DAS28ESR.low) = Low
+- ``\\leq`` $(cutoff.DAS28ESR.moderate) = Moderate
+- ``>`` $(cutoff.DAS28ESR.moderate) = High
 
 # External links
 

--- a/src/types/sdai.jl
+++ b/src/types/sdai.jl
@@ -17,10 +17,10 @@ Store component measures of the Simplified Disease Activity Index, or SDAI.
 
 # Categories
 
-- ``\\leq`` $(cont_cutoff.SDAI.low) = Remission
-- ``\\leq`` $(cont_cutoff.SDAI.low) = Low
-- ``\\leq`` $(cont_cutoff.SDAI.moderate) = Moderate
-- ``>`` $(cont_cutoff.SDAI.moderate) = High
+- ``\\leq`` $(cutoff.SDAI.low) = Remission
+- ``\\leq`` $(cutoff.SDAI.low) = Low
+- ``\\leq`` $(cutoff.SDAI.moderate) = Moderate
+- ``>`` $(cutoff.SDAI.moderate) = High
 
 # External links
 

--- a/src/utils/auxfuns.jl
+++ b/src/utils/auxfuns.jl
@@ -5,3 +5,23 @@ function values_flatten(x::NamedTuple)
                    collect
     return property_vec
 end
+
+function seq_check(x::Real, conds::NamedTuple)
+    funs = values(conds)
+    i = 1
+    for fun in funs
+        fun(x) && break
+        i += 1
+    end
+    return string(keys(conds)[i])
+end
+
+#=
+function seq_check(x::BooleanComposite, conds::NamedTuple)
+    funs = values(conds)
+    for fun in funs
+        fun(x) || return false
+    end
+    return true
+end
+=#

--- a/src/utils/constants.jl
+++ b/src/utils/constants.jl
@@ -1,4 +1,4 @@
-cont_cutoff = (
+cutoff = (
     DAS28ESR=(
         remission=2.6,
         low=3.2,
@@ -19,13 +19,47 @@ cont_cutoff = (
         low=10.0,
         moderate=22.0
     ),
+    BooleanRemission=(
+        tjc=1,
+        sjc=1,
+        pga=10u"mm",
+        crp=1.0u"mg/dL",
+    ),
 )
 
 bool_cutoff_funs = (
-    tjc=(x; offset = 0) -> tjc(x) <= 1 + offset,
-    sjc=(x; offset = 0) -> sjc(x) <= 1 + offset,
-    pga=(x; offset = 0u"mm") -> pga(x) <= 10u"mm" + offset,
-    crp=(x; offset = 0u"mg/dL") -> crp(x) <= 1.0u"mg/dL" + offset,
+    tjc=(x; offset = 0) -> tjc(x) <= cutoff.BooleanRemission.tjc + offset,
+    sjc=(x; offset = 0) -> sjc(x) <= cutoff.BooleanRemission.sjc + offset,
+    pga=(x; offset = 0u"mm") -> pga(x) <= cutoff.BooleanRemission.pga + offset,
+    crp=(x; offset = 0u"mg/dL") -> crp(x) <= cutoff.BooleanRemission.crp + offset,
+)
+
+# TODO add a check that asserts that all continuous composites have an entry here
+cont_cutoff_funs = (
+    DAS28ESR=(
+        remission=(x) -> x < cutoff.DAS28ESR.remission,
+        low=(x) -> x <= cutoff.DAS28ESR.low,
+        moderate=(x) -> x <= cutoff.DAS28ESR.moderate,
+        high=(x) -> x > cutoff.DAS28ESR.moderate,
+    ),
+    DAS28CRP=(
+        remission=(x) -> x < cutoff.DAS28CRP.remission,
+        low=(x) -> x <= cutoff.DAS28CRP.low,
+        moderate=(x) -> x <= cutoff.DAS28CRP.moderate,
+        high=(x) -> x > cutoff.DAS28CRP.moderate,
+    ),
+    SDAI=(
+        remission=(x) -> x <= cutoff.SDAI.remission,
+        low=(x) -> x <= cutoff.SDAI.low,
+        moderate=(x) -> x <= cutoff.SDAI.moderate,
+        high=(x) -> x > cutoff.SDAI.moderate,
+    ),
+    CDAI=(
+        remission=(x) -> x <= cutoff.CDAI.remission,
+        low=(x) -> x <= cutoff.CDAI.low,
+        moderate=(x) -> x <= cutoff.CDAI.moderate,
+        high=(x) -> x > cutoff.CDAI.moderate,
+    ),
 )
 
 weights_das28esr = (

--- a/test/types/boolean.jl
+++ b/test/types/boolean.jl
@@ -1,4 +1,4 @@
-boolrem = BooleanRemission(tjc=1, sjc=0, pga=14u"mm", crp=0.4u"mg/dl")
+boolrem = BooleanRemission(tjc=1, sjc=0, pga=14u"mm", crp=0.4u"mg/dL")
 
 @testset "Original BoolRem" begin
     @test boolrem isa AbstractComposite

--- a/test/types/cdai.jl
+++ b/test/types/cdai.jl
@@ -33,8 +33,8 @@ end
 end
 
 @testset "Categorise CDAI" begin
-    @test categorise(cdai) == "Remission"
-    @test categorise.(CDAI, [2.79, 2.81]) == ["Remission", "Low"]
-    @test categorise.(CDAI, [9.99, 10.01]) == ["Low", "Moderate"]
-    @test categorise.(CDAI, [21.99, 22.01]) == ["Moderate", "High"]
+    @test categorise(cdai) == "remission"
+    @test categorise.(CDAI, [2.79, 2.81]) == ["remission", "low"]
+    @test categorise.(CDAI, [9.99, 10.01]) == ["low", "moderate"]
+    @test categorise.(CDAI, [21.99, 22.01]) == ["moderate", "high"]
 end

--- a/test/types/das28.jl
+++ b/test/types/das28.jl
@@ -52,10 +52,10 @@ end
 end
 
 @testset "Categorise DAS28ESR" begin
-    @test categorise(das28e) == "Moderate"
-    @test categorise.(DAS28ESR, [2.59, 2.61]) == ["Remission", "Low"]
-    @test categorise.(DAS28ESR, [3.19, 3.21]) == ["Low", "Moderate"]
-    @test categorise.(DAS28ESR, [5.09, 5.11]) == ["Moderate", "High"]
+    @test categorise(das28e) == "moderate"
+    @test categorise.(DAS28ESR, [2.59, 2.61]) == ["remission", "low"]
+    @test categorise.(DAS28ESR, [3.19, 3.21]) == ["low", "moderate"]
+    @test categorise.(DAS28ESR, [5.09, 5.11]) == ["moderate", "high"]
 end
 
 @testset "Construct DAS28CRP" begin
@@ -88,12 +88,16 @@ end
     @test faceted(das28c, facets) isa Faceted{<:ContinuousComposite}
     @test score(faceted(das28c, facets)) == score(das28c)
     @test sum(decompose(faceted(das28c, facets), digits=5)) ≈ 1.0 atol = 1e-5
-    @test try faceted(das28c, (abc=[:tjc, :pga], cde=[:tjc, :apr])) catch e; e isa ErrorException end
+    @test try
+        faceted(das28c, (abc=[:tjc, :pga], cde=[:tjc, :apr]))
+    catch e
+        e isa ErrorException
+    end
 end
 
 @testset "Categorise DAS28CRP" begin
-    @test categorise(das28c) == "Moderate"
-    @test categorise.(DAS28CRP, [2.39, 2.51]) == ["Remission", "Low"]
-    @test categorise.(DAS28CRP, [2.89, 2.91]) == ["Low", "Moderate"]
-    @test categorise.(DAS28CRP, [4.59, 4.61]) == ["Moderate", "High"]
+    @test categorise(das28c) == "moderate"
+    @test categorise.(DAS28CRP, [2.39, 2.51]) == ["remission", "low"]
+    @test categorise.(DAS28CRP, [2.89, 2.91]) == ["low", "moderate"]
+    @test categorise.(DAS28CRP, [4.59, 4.61]) == ["moderate", "high"]
 end

--- a/test/types/sdai.jl
+++ b/test/types/sdai.jl
@@ -35,8 +35,8 @@ end
 end
 
 @testset "Categorise SDAI" begin
-    @test categorise(sdai) == "Remission"
-    @test categorise.(SDAI, [3.29, 3.31]) == ["Remission", "Low"]
-    @test categorise.(SDAI, [10.99, 11.01]) == ["Low", "Moderate"]
-    @test categorise.(SDAI, [25.99, 26.01]) == ["Moderate", "High"]
+    @test categorise(sdai) == "remission"
+    @test categorise.(SDAI, [3.29, 3.31]) == ["remission", "low"]
+    @test categorise.(SDAI, [10.99, 11.01]) == ["low", "moderate"]
+    @test categorise.(SDAI, [25.99, 26.01]) == ["moderate", "high"]
 end


### PR DESCRIPTION
- `categorise` is now an impure function since it indexes a `NamedTuple` with cutoffs
- benchmarking suggests that 1 microsecond is lost due to the lookup that this incurs (50% slowdown)
- the remaining time is mostly spent in `weight`, and likely even in building the type-unstable `Tuple` with `getproperty.(Ref(x), components(x)`. Not sure how to solve this yet, and eventually might revisit this code to speed it up.