### PR TITLE
fix cutoff lookup

### DIFF
--- a/src/functions/categorise.jl
+++ b/src/functions/categorise.jl
@@ -13,7 +13,7 @@ julia> categorise(SDAI, 3.6)
 ```
 """
 function categorise(::Type{T}, s::Real) where {T<:ContinuousComposite}
-    return seq_check(s, getproperty(cont_cutoff_funs, Symbol(T)))
+    return seq_check(s, getproperty(cont_cutoff_funs, _typename(T)))
 end
 # This implementation is roughly half as 2.5 times slower than hard coding
 # cutoffs into each categorise function

--- a/src/functions/isremission.jl
+++ b/src/functions/isremission.jl
@@ -1,5 +1,7 @@
+_typename(x::DataType) = Symbol(split(string(nameof(x)), ".")[end])
+
 function isremission(::Type{T}, x::AbstractComposite) where {T<:ContinuousComposite}
-    cut = getproperty(cont_cutoff_funs, Symbol(T))
+    cut = getproperty(cont_cutoff_funs, _typename(T))
     return cut.remission(score(x))
 end
 

--- a/src/utils/auxfuns.jl
+++ b/src/utils/auxfuns.jl
@@ -6,6 +6,8 @@ function values_flatten(x::NamedTuple)
     return property_vec
 end
 
+_typename(x::DataType) = Symbol(split(string(nameof(x)), ".")[end])
+
 function seq_check(x::Real, conds::NamedTuple)
     funs = values(conds)
     i = 1


### PR DESCRIPTION
- use a function that gets the composite type for indexing the lookup tuple even when used in a module.
- issues like these are a convincing argument against this kind of backend... I should drop the lookup tables in another release!