### PR TITLE
delete doubly-defined function `_typename`

### DIFF
--- a/src/functions/isremission.jl
+++ b/src/functions/isremission.jl
@@ -1,5 +1,3 @@
-_typename(x::DataType) = Symbol(split(string(nameof(x)), ".")[end])
-
 function isremission(::Type{T}, x::AbstractComposite) where {T<:ContinuousComposite}
     cut = getproperty(cont_cutoff_funs, _typename(T))
     return cut.remission(score(x))


### PR DESCRIPTION
forgot to hit save after moving it to the helper functions, oopsies