### PR TITLE
fix faceted decompose

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,7 +22,7 @@ Now you're ready to start working with composite scores:
 
 ```julia
 using RheumaComposites, Unitful
-das28 = DAS28ESR(tjc=4, sjc=3, pga=41u"mm", apr=19u"mm/hr")
+das28 = DAS28ESR(tjc=4, sjc=3, pga=4.1, apr=19; units=(pga=u"cm", apr=u"mm/hr"))
 score(das28)
 isremission(das28)
 categorise(das28)

--- a/src/functions/decompose.jl
+++ b/src/functions/decompose.jl
@@ -46,6 +46,6 @@ function decompose(x::Faceted{<:ContinuousComposite}; digits=3)
     fields_per_facet = values(x.facets)
     decomp = decompose(root; digits=digits)
     # FIXME Speed: looped `getindex` slows this down a lot, how to do better?
-    sum_per_facet = mapreduce(fields -> getindex.(Ref(decomp), fields), +, fields_per_facet)
+    sum_per_facet = map(fields -> sum(getindex.(Ref(decomp), fields)), fields_per_facet)
     return Dict{Symbol, Float64}(Pair.(facets, sum_per_facet))
 end

--- a/src/functions/decompose.jl
+++ b/src/functions/decompose.jl
@@ -36,8 +36,8 @@ julia> root = DAS28ESR(tjc=4, sjc=5, pga=14, apr=12);
 
 julia> faceted(root, (objective=[:sjc, :apr], subjective=[:tjc, :pga])) |> decompose
 Dict{Symbol, Float64} with 2 entries:
-  :subjective => 0.525
-  :objective  => 0.474
+  :subjective => 0.357
+  :objective  => 0.642
 ```
 """
 function decompose(x::Faceted{<:ContinuousComposite}; digits=3)

--- a/src/types/das28.jl
+++ b/src/types/das28.jl
@@ -94,7 +94,7 @@ struct DAS28ESR <: DAS28
 
         valid_joints.([tjc, sjc])
         valid_vas(ucomponents.pga)
-        valid_apr(ucomponents.apr)
+        valid_apr(ucomponents.apr, 1)
 
         names = keys(ntvals)
         vals = ustrip.(values(ucomponents))

--- a/src/utils/valid.jl
+++ b/src/utils/valid.jl
@@ -11,4 +11,5 @@ function valid_vas(x)
 end
 
 # Check if APR value is valid
-valid_apr(x) = 0 <= ustrip(x)
+valid_apr(x) = 0 <= ustrip(x) || throw(error("Invalid APR"))
+valid_apr(x, min) = min <= ustrip(x) || throw(error("Invalid APR"))

--- a/test/types/das28.jl
+++ b/test/types/das28.jl
@@ -48,6 +48,8 @@ end
     @test faceted(das28e, facets) isa Faceted{<:ContinuousComposite}
     @test score(faceted(das28e, facets)) == score(das28e)
     @test sum(values(decompose(faceted(das28e, facets), digits=5))) ≈ 1.0 atol = 1e-5
+    @test decompose(faceted(DAS28ESR(tjc=1, sjc=0, pga=0, apr=1), facets))[:subjective] == 1
+    @test decompose(faceted(DAS28ESR(tjc=0, sjc=1, pga=0, apr=1), facets))[:objective] == 1
 end
 
 @testset "Categorise DAS28ESR" begin
@@ -104,3 +106,12 @@ end
     @test categorise.(DAS28CRP, [2.89, 2.91]) == ["low", "moderate"]
     @test categorise.(DAS28CRP, [4.59, 4.61]) == ["moderate", "high"]
 end
+
+xx = DAS28ESR(tjc=1, sjc=0, pga=0, apr=1)
+
+decompose(faceted(xx, facets))
+
+# FIXME This should not return 0.56 for TJC weight
+weight(xx)
+
+decompose(xx)


### PR DESCRIPTION
- replace `mapreduce` in `decompose` for `Faceted` with `map`  to correctly return sums for each dimension.
- add method of  `valid_apr` that allows specifying a custom minimum because ESR cannot be below 1
- add said `valid_apr` method to DAS28ESR struct
- add tests