### PR TITLE
fix remission docstrings

### DIFF
--- a/src/types/cdai.jl
+++ b/src/types/cdai.jl
@@ -14,7 +14,7 @@ Optionally specify the units for each component using [`Unitful.@u_str`](@extref
 
 # Categories
 
-- ``<`` $(cutoff.CDAI.low) = Remission
+- ``<`` $(cutoff.CDAI.remission) = Remission
 - ``\\leq`` $(cutoff.CDAI.low) = Low
 - ``\\leq`` $(cutoff.CDAI.moderate) = Moderate
 - ``>`` $(cutoff.CDAI.moderate) = High

--- a/src/types/dapsa.jl
+++ b/src/types/dapsa.jl
@@ -14,7 +14,7 @@ Optionally specify the units for each component using [`Unitful.@u_str`](@extref
 
 # Categories
 
-- ``\\leq`` $(cutoff.DAPSA.low) = Remission
+- ``\\leq`` $(cutoff.DAPSA.remission) = Remission
 - ``\\leq`` $(cutoff.DAPSA.low) = Low
 - ``\\leq`` $(cutoff.DAPSA.moderate) = Moderate
 - ``>`` $(cutoff.DAPSA.moderate) = High

--- a/src/types/das28.jl
+++ b/src/types/das28.jl
@@ -26,7 +26,7 @@ Optionally specify the units for each component using [`Unitful.@u_str`](@extref
 
 # Categories
 
-- ``<`` $(cutoff.DAS28CRP.low) = Remission
+- ``<`` $(cutoff.DAS28CRP.remission) = Remission
 - ``\\leq`` $(cutoff.DAS28CRP.low) = Low
 - ``\\leq`` $(cutoff.DAS28CRP.moderate) = Moderate
 - ``>`` $(cutoff.DAS28CRP.moderate) = High
@@ -72,7 +72,7 @@ Optionally specify the units for each component using [`Unitful.@u_str`](@extref
 
 # Categories
 
-- ``<`` $(cutoff.DAS28ESR.low) = Remission
+- ``<`` $(cutoff.DAS28ESR.remission) = Remission
 - ``\\leq`` $(cutoff.DAS28ESR.low) = Low
 - ``\\leq`` $(cutoff.DAS28ESR.moderate) = Moderate
 - ``>`` $(cutoff.DAS28ESR.moderate) = High

--- a/test/types/das28.jl
+++ b/test/types/das28.jl
@@ -103,12 +103,3 @@ end
     @test categorise.(DAS28CRP, [2.89, 2.91]) == ["low", "moderate"]
     @test categorise.(DAS28CRP, [4.59, 4.61]) == ["moderate", "high"]
 end
-
-xx = DAS28ESR(tjc=1, sjc=0, pga=0u"mm", apr=1u"mm/hr")
-
-decompose(faceted(xx, facets))
-
-# FIXME This should not return 0.56 for TJC weight
-weight(xx)
-
-decompose(xx)


### PR DESCRIPTION
The docstrings for remission in CDAI, DAS28 and DAPSA incorrectly showed the values for the `Low` disease activity cutoffs.