### PR TITLE
Implement partial revised boolrem

### DIFF
--- a/src/functions/isremission.jl
+++ b/src/functions/isremission.jl
@@ -10,6 +10,10 @@ function isremission(::Type{<:Revised{BooleanRemission}}, x)
     return mapreduce((o, c) -> c <= 1 + o, &, x.offsets, (values ∘ root)(x))
 end
 
+function isremission(::Type{<:Partial{N,<:Revised{BooleanRemission}}}, x) where {N}
+    return mapreduce((o, c) -> c <= 1 + o, &, root(x).offsets, values(x))
+end
+
 """
     isremission(::Type{T}, s::Real) where {T<:ContinuousComposite}
 

--- a/test/types/boolean.jl
+++ b/test/types/boolean.jl
@@ -18,6 +18,12 @@ end
     @test isremission(threeitem(boolrem))
 end
 
+@testset "Partial revised BoolRem" begin
+    boolrem_o_rem = BooleanRemission(tjc=2, sjc=0, pga=1.4u"cm", crp=0.4u"mg/dL")
+    @test !isremission(partial(revised(boolrem_o_rem), [:tjc, :pga]))
+    @test isremission(partial(revised(boolrem_o_rem), [:sjc, :crp]))
+end
+
 @testset "Misspecified BoolRem" begin
     @test try
         weight(boolrem)


### PR DESCRIPTION
Allows specifying partial revised BooleanRemission composites:

```julia
boolrem_o_rem = BooleanRemission(tjc=2, sjc=0, pga=1.4u"cm", crp=0.4u"mg/dL")
```

Adds methods for `isremission` to check if the partial boolean composite conforms to the revised remission definition:

```julia
isremission(partial(revised(boolrem_o_rem), [:tjc, :pga]))
# false
isremission(partial(revised(boolrem_o_rem), [:sjc, :crp]))
# true
```